### PR TITLE
Add fortran_order field to NpyArray to allow loading of Fortran-ordered ...

### DIFF
--- a/cnpy.h
+++ b/cnpy.h
@@ -21,6 +21,7 @@ namespace cnpy {
         char* data;
         std::vector<unsigned int> shape;
         unsigned int word_size;
+        bool fortran_order;
         void destruct() {delete[] data;}
     };
     
@@ -36,7 +37,7 @@ namespace cnpy {
     char BigEndianTest();
     char map_type(const std::type_info& t);
     template<typename T> std::vector<char> create_npy_header(const T* data, const unsigned int* shape, const unsigned int ndims);
-    void parse_npy_header(FILE* fp,unsigned int& word_size, unsigned int*& shape, unsigned int& ndims);
+    void parse_npy_header(FILE* fp,unsigned int& word_size, unsigned int*& shape, unsigned int& ndims, bool& fortran_order);
     void parse_zip_footer(FILE* fp, unsigned short& nrecs, unsigned int& global_header_size, unsigned int& global_header_offset);
     npz_t npz_load(std::string fname);
     NpyArray npz_load(std::string fname, std::string varname);
@@ -70,7 +71,9 @@ namespace cnpy {
             //file exists. we need to append to it. read the header, modify the array size
             unsigned int word_size, tmp_dims;
             unsigned int* tmp_shape = 0;
-            parse_npy_header(fp,word_size,tmp_shape,tmp_dims);
+            bool fortran_order;
+            parse_npy_header(fp,word_size,tmp_shape,tmp_dims,fortran_order);
+            assert(!fortran_order);
 
             if(word_size != sizeof(T)) {
                 std::cout<<"libnpy error: "<<fname<<" has word size "<<word_size<<" but npy_save appending data sized "<<sizeof(T)<<"\n";


### PR DESCRIPTION
This adds a NpyArray field 'fortran_order' that indicates the array ordering.
