### PR TITLE
Various fixes and modernizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ endif(COMMAND cmake_policy)
 
 project(CNPY)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 option(ENABLE_STATIC "Build static (.a) library" ON)
 
 add_library(cnpy SHARED "cnpy.cpp")

--- a/README
+++ b/README
@@ -17,7 +17,7 @@ Using:
 
 To use, #include"cnpy.h" in your source code. Compile the source code mycode.cpp as
 
-g++ -o mycode mycode.cpp -L/path/to/install/dir -lcnpy
+g++ -o mycode mycode.cpp -L/path/to/install/dir -lcnpy --std=c++11
 
 Description:
 

--- a/README
+++ b/README
@@ -24,14 +24,13 @@ Description:
 There are two functions for writing data: npy_save, npz_save.
 
 There are 3 functions for reading. npy_load will load a .npy file. npz_load(fname) will load a .npz and return a dictionary of NpyArray structues. npz_load(fname,varname) will load and return the NpyArray for data varname from the specified .npz file.
-Note that NpyArray allocates char* data using new[] and *will not* delete the data upon the NpyArray destruction. You are responsible for delete the data yourself.
 
-The data structure for loaded data is below. Data is loaded into a a raw byte array. The array shape and word size are read from the npy header. You are responsible for casting/copying the data to its intended data type.
+The data structure for loaded data is below. Data is accessed via the data<T>() method, which returns a pointer of the specified type (which must match the underlying datatype of the data). The array shape and word size are read from the npy header.
 
 struct NpyArray {
-    char* data;
     std::vector<size_t> shape;
     size_t word_size;
+    template<typename T> T* data();
 };
 
 See example1.cpp for examples of how to use the library. example1 will also be build during cmake installation.

--- a/README
+++ b/README
@@ -30,8 +30,8 @@ The data structure for loaded data is below. Data is loaded into a a raw byte ar
 
 struct NpyArray {
     char* data;
-    std::vector<unsigned int> shape;
-    unsigned int word_size;
+    std::vector<size_t> shape;
+    size_t word_size;
 };
 
 See example1.cpp for examples of how to use the library. example1 will also be build during cmake installation.

--- a/cnpy.cpp
+++ b/cnpy.cpp
@@ -56,7 +56,7 @@ template<> std::vector<char>& cnpy::operator+=(std::vector<char>& lhs, const cha
     return lhs;
 }
 
-void cnpy::parse_npy_header(FILE* fp, unsigned int& word_size, unsigned int*& shape, unsigned int& ndims, bool& fortran_order) {  
+void cnpy::parse_npy_header(FILE* fp, size_t& word_size, size_t*& shape, size_t& ndims, bool& fortran_order) {  
     char buffer[256];
     size_t res = fread(buffer,sizeof(char),11,fp);       
     if(res != 11)
@@ -76,8 +76,8 @@ void cnpy::parse_npy_header(FILE* fp, unsigned int& word_size, unsigned int*& sh
     std::string str_shape = header.substr(loc1+1,loc2-loc1-1);
     if(str_shape[str_shape.size()-1] == ',') ndims = 1;
     else ndims = std::count(str_shape.begin(),str_shape.end(),',')+1;
-    shape = new unsigned int[ndims];
-    for(unsigned int i = 0;i < ndims;i++) {
+    shape = new size_t[ndims];
+    for(size_t i = 0;i < ndims;i++) {
         loc1 = str_shape.find(",");
         shape[i] = atoi(str_shape.substr(0,loc1).c_str());
         str_shape = str_shape.substr(loc1+1);
@@ -98,7 +98,7 @@ void cnpy::parse_npy_header(FILE* fp, unsigned int& word_size, unsigned int*& sh
     word_size = atoi(str_ws.substr(0,loc2).c_str());
 }
 
-void cnpy::parse_zip_footer(FILE* fp, unsigned short& nrecs, unsigned int& global_header_size, unsigned int& global_header_offset)
+void cnpy::parse_zip_footer(FILE* fp, unsigned short& nrecs, size_t& global_header_size, size_t& global_header_offset)
 {
     std::vector<char> footer(22);
     fseek(fp,-22,SEEK_END);
@@ -122,16 +122,16 @@ void cnpy::parse_zip_footer(FILE* fp, unsigned short& nrecs, unsigned int& globa
 }
 
 cnpy::NpyArray load_the_npy_file(FILE* fp) {
-    unsigned int* shape;
-    unsigned int ndims, word_size;
+    size_t* shape;
+    size_t ndims, word_size;
     bool fortran_order;
     cnpy::parse_npy_header(fp,word_size,shape,ndims,fortran_order);
     unsigned long long size = 1; //long long so no overflow when multiplying by word_size
-    for(unsigned int i = 0;i < ndims;i++) size *= shape[i];
+    for(size_t i = 0;i < ndims;i++) size *= shape[i];
 
     cnpy::NpyArray arr;
     arr.word_size = word_size;
-    arr.shape = std::vector<unsigned int>(shape,shape+ndims);
+    arr.shape = std::vector<size_t>(shape,shape+ndims);
     arr.data = new char[size*word_size];    
     arr.fortran_order = fortran_order;
     size_t nread = fread(arr.data,word_size,size,fp);
@@ -219,7 +219,7 @@ cnpy::NpyArray cnpy::npz_load(std::string fname, std::string varname) {
         }
         else {
             //skip past the data
-            unsigned int size = *(unsigned int*) &local_header[22];
+            size_t size = *(unsigned int*) &local_header[22];
             fseek(fp,size,SEEK_CUR);
         }
     }

--- a/cnpy.cpp
+++ b/cnpy.cpp
@@ -10,9 +10,8 @@
 #include<iomanip>
 
 char cnpy::BigEndianTest() {
-    unsigned char x[] = {1,0};
-    short y = *(short*) x;
-    return y == 1 ? '<' : '>';
+    int x = 1;
+    return (((char *)&x)[0]) ? '<' : '>';
 }
 
 char cnpy::map_type(const std::type_info& t)

--- a/cnpy.h
+++ b/cnpy.h
@@ -218,6 +218,18 @@ namespace cnpy {
         fclose(fp);
     }
 
+    template<typename T> void npy_save(std::string fname, const std::vector<T> data, std::string mode = "w") {
+        std::vector<size_t> shape;
+        shape.push_back(data.size());
+        npy_save(fname, &data[0], shape, mode);
+    }
+
+    template<typename T> void npz_save(std::string zipname, std::string fname, const std::vector<T> data, std::string mode = "w") {
+        std::vector<size_t> shape;
+        shape.push_back(data.size());
+        npz_save(zipname, fname, &data[0], shape, mode);
+    }
+
     template<typename T> std::vector<char> create_npy_header(const std::vector<size_t>& shape) {  
 
         std::vector<char> dict;

--- a/cnpy.h
+++ b/cnpy.h
@@ -15,6 +15,7 @@
 #include<cassert>
 #include<zlib.h>
 #include<map>
+#include<stdint.h>
 
 namespace cnpy {
 
@@ -39,7 +40,7 @@ namespace cnpy {
     char map_type(const std::type_info& t);
     template<typename T> std::vector<char> create_npy_header(const size_t* shape, const size_t ndims);
     void parse_npy_header(FILE* fp,size_t& word_size, size_t*& shape, size_t& ndims, bool& fortran_order);
-    void parse_zip_footer(FILE* fp, unsigned short& nrecs, size_t& global_header_size, size_t& global_header_offset);
+    void parse_zip_footer(FILE* fp, uint16_t& nrecs, size_t& global_header_size, size_t& global_header_offset);
     npz_t npz_load(std::string fname);
     NpyArray npz_load(std::string fname, std::string varname);
     NpyArray npy_load(std::string fname);
@@ -120,7 +121,7 @@ namespace cnpy {
 
         //now, on with the show
         FILE* fp = NULL;
-        unsigned short nrecs = 0;
+        uint16_t nrecs = 0;
         size_t global_header_offset = 0;
         std::vector<char> global_header;
 
@@ -147,53 +148,53 @@ namespace cnpy {
 
         std::vector<char> npy_header = create_npy_header<T>(shape,ndims);
 
-        unsigned long nels = 1;
+        size_t nels = 1;
         for (size_t m=0; m<ndims; m++ ) nels *= shape[m];
         int nbytes = nels*sizeof(T) + npy_header.size();
 
         //get the CRC of the data to be added
-        unsigned int crc = crc32(0L,(unsigned char*)&npy_header[0],npy_header.size());
-        crc = crc32(crc,(unsigned char*)data,nels*sizeof(T));
+        uint32_t crc = crc32(0L,(uint8_t*)&npy_header[0],npy_header.size());
+        crc = crc32(crc,(uint8_t*)data,nels*sizeof(T));
 
         //build the local header
         std::vector<char> local_header;
         local_header += "PK"; //first part of sig
-        local_header += (unsigned short) 0x0403; //second part of sig
-        local_header += (unsigned short) 20; //min version to extract
-        local_header += (unsigned short) 0; //general purpose bit flag
-        local_header += (unsigned short) 0; //compression method
-        local_header += (unsigned short) 0; //file last mod time
-        local_header += (unsigned short) 0;     //file last mod date
-        local_header += (unsigned int) crc; //crc
-        local_header += (unsigned int) nbytes; //compressed size
-        local_header += (unsigned int) nbytes; //uncompressed size
-        local_header += (unsigned short) fname.size(); //fname length
-        local_header += (unsigned short) 0; //extra field length
+        local_header += (uint16_t) 0x0403; //second part of sig
+        local_header += (uint16_t) 20; //min version to extract
+        local_header += (uint16_t) 0; //general purpose bit flag
+        local_header += (uint16_t) 0; //compression method
+        local_header += (uint16_t) 0; //file last mod time
+        local_header += (uint16_t) 0;     //file last mod date
+        local_header += (uint32_t) crc; //crc
+        local_header += (uint32_t) nbytes; //compressed size
+        local_header += (uint32_t) nbytes; //uncompressed size
+        local_header += (uint16_t) fname.size(); //fname length
+        local_header += (uint16_t) 0; //extra field length
         local_header += fname;
 
         //build global header
         global_header += "PK"; //first part of sig
-        global_header += (unsigned short) 0x0201; //second part of sig
-        global_header += (unsigned short) 20; //version made by
+        global_header += (uint16_t) 0x0201; //second part of sig
+        global_header += (uint16_t) 20; //version made by
         global_header.insert(global_header.end(),local_header.begin()+4,local_header.begin()+30);
-        global_header += (unsigned short) 0; //file comment length
-        global_header += (unsigned short) 0; //disk number where file starts
-        global_header += (unsigned short) 0; //internal file attributes
-        global_header += (unsigned int) 0; //external file attributes
-        global_header += (unsigned int) global_header_offset; //relative offset of local file header, since it begins where the global header used to begin
+        global_header += (uint16_t) 0; //file comment length
+        global_header += (uint16_t) 0; //disk number where file starts
+        global_header += (uint16_t) 0; //internal file attributes
+        global_header += (uint32_t) 0; //external file attributes
+        global_header += (uint32_t) global_header_offset; //relative offset of local file header, since it begins where the global header used to begin
         global_header += fname;
 
         //build footer
         std::vector<char> footer;
         footer += "PK"; //first part of sig
-        footer += (unsigned short) 0x0605; //second part of sig
-        footer += (unsigned short) 0; //number of this disk
-        footer += (unsigned short) 0; //disk where footer starts
-        footer += (unsigned short) (nrecs+1); //number of records on this disk
-        footer += (unsigned short) (nrecs+1); //total number of records
-        footer += (unsigned int) global_header.size(); //nbytes of global headers
-        footer += (unsigned int) (global_header_offset + nbytes + local_header.size()); //offset of start of global headers, since global header now starts after newly written array
-        footer += (unsigned short) 0; //zip file comment length
+        footer += (uint16_t) 0x0605; //second part of sig
+        footer += (uint16_t) 0; //number of this disk
+        footer += (uint16_t) 0; //disk where footer starts
+        footer += (uint16_t) (nrecs+1); //number of records on this disk
+        footer += (uint16_t) (nrecs+1); //total number of records
+        footer += (uint32_t) global_header.size(); //nbytes of global headers
+        footer += (uint32_t) (global_header_offset + nbytes + local_header.size()); //offset of start of global headers, since global header now starts after newly written array
+        footer += (uint16_t) 0; //zip file comment length
 
         //write everything      
         fwrite(&local_header[0],sizeof(char),local_header.size(),fp);
@@ -229,7 +230,7 @@ namespace cnpy {
         header += "NUMPY";
         header += (char) 0x01; //major version of numpy format
         header += (char) 0x00; //minor version of numpy format
-        header += (unsigned short) dict.size();
+        header += (uint16_t) dict.size();
         header.insert(header.end(),dict.begin(),dict.end());
 
         return header;

--- a/cnpy.h
+++ b/cnpy.h
@@ -37,7 +37,7 @@ namespace cnpy {
 
     char BigEndianTest();
     char map_type(const std::type_info& t);
-    template<typename T> std::vector<char> create_npy_header(const T* data, const unsigned int* shape, const unsigned int ndims);
+    template<typename T> std::vector<char> create_npy_header(const unsigned int* shape, const unsigned int ndims);
     void parse_npy_header(FILE* fp,unsigned int& word_size, unsigned int*& shape, unsigned int& ndims, bool& fortran_order);
     void parse_zip_footer(FILE* fp, unsigned short& nrecs, unsigned int& global_header_size, unsigned int& global_header_offset);
     npz_t npz_load(std::string fname);
@@ -57,7 +57,7 @@ namespace cnpy {
     template<> std::vector<char>& operator+=(std::vector<char>& lhs, const char* rhs); 
 
 
-    template<typename T> std::string tostring(T i, int pad = 0, char padval = ' ') {
+    template<typename T> std::string tostring(T i) {
         std::stringstream s;
         s << i;
         return s.str();
@@ -94,7 +94,7 @@ namespace cnpy {
             tmp_shape[0] += shape[0];
 
             fseek(fp,0,SEEK_SET);
-            std::vector<char> header = create_npy_header(data,tmp_shape,ndims);
+            std::vector<char> header = create_npy_header<T>(tmp_shape,ndims);
             fwrite(&header[0],sizeof(char),header.size(),fp);
             fseek(fp,0,SEEK_END);
 
@@ -102,7 +102,7 @@ namespace cnpy {
         }
         else {
             fp = fopen(fname.c_str(),"wb");
-            std::vector<char> header = create_npy_header(data,shape,ndims);
+            std::vector<char> header = create_npy_header<T>(shape,ndims);
             fwrite(&header[0],sizeof(char),header.size(),fp);
         }
 
@@ -145,7 +145,7 @@ namespace cnpy {
             fp = fopen(zipname.c_str(),"wb");
         }
 
-        std::vector<char> npy_header = create_npy_header(data,shape,ndims);
+        std::vector<char> npy_header = create_npy_header<T>(shape,ndims);
 
         unsigned long nels = 1;
         for (int m=0; m<ndims; m++ ) nels *= shape[m];
@@ -204,7 +204,7 @@ namespace cnpy {
         fclose(fp);
     }
 
-    template<typename T> std::vector<char> create_npy_header(const T* data, const unsigned int* shape, const unsigned int ndims) {  
+    template<typename T> std::vector<char> create_npy_header(const unsigned int* shape, const unsigned int ndims) {  
 
         std::vector<char> dict;
         dict += "{'descr': '";

--- a/cnpy.h
+++ b/cnpy.h
@@ -24,17 +24,23 @@ namespace cnpy {
         NpyArray(const std::vector<size_t>& _shape, size_t _word_size, bool _fortran_order) :
             shape(_shape), word_size(_word_size), fortran_order(_fortran_order)
         {
-            size_t num_bytes = word_size;
-            for(size_t i = 0;i < shape.size();i++) num_bytes *= shape[i];
+            num_vals = 1;
+            for(size_t i = 0;i < shape.size();i++) num_vals *= shape[i];
             data_holder = std::shared_ptr<std::vector<char>>(
-                new std::vector<char>(num_bytes));
+                new std::vector<char>(num_vals * word_size));
         }
 
-        NpyArray() : shape(0), word_size(0), fortran_order(0) { }
+        NpyArray() : shape(0), word_size(0), fortran_order(0), num_vals(0) { }
 
         template<typename T>
         T* data() {
             return reinterpret_cast<T*>(&(*data_holder)[0]);
+        }
+
+        template<typename T>
+        std::vector<T> as_vec() {
+            const T* p = data<T>();
+            return std::vector<T>(p, p+num_vals);
         }
 
         size_t num_bytes() {
@@ -45,6 +51,7 @@ namespace cnpy {
         std::vector<size_t> shape;
         size_t word_size;
         bool fortran_order;
+        size_t num_vals;
     };
     
     struct npz_t : public std::map<std::string, NpyArray>

--- a/example1.cpp
+++ b/example1.cpp
@@ -16,7 +16,7 @@ int main()
     for(int i = 0;i < Nx*Ny*Nz;i++) data[i] = std::complex<double>(rand(),rand());
 
     //save it to file
-    const unsigned int shape[] = {Nz,Ny,Nx};
+    const size_t shape[] = {Nz,Ny,Nx};
     cnpy::npy_save("arr1.npy",data,shape,3,"w");
 
     //load it into a new array
@@ -36,7 +36,7 @@ int main()
     //non-array variables are treated as 1D arrays with 1 element
     double myVar1 = 1.2;
     char myVar2 = 'a';
-    unsigned int shape2[] = {1};
+    size_t shape2[] = {1};
     cnpy::npz_save("out.npz","myVar1",&myVar1,shape2,1,"w"); //"w" overwrites any existing file
     cnpy::npz_save("out.npz","myVar2",&myVar2,shape2,1,"a"); //"a" appends to the file we created above
     cnpy::npz_save("out.npz","arr1",data,shape,3,"a"); //"a" appends to the file we created above

--- a/example1.cpp
+++ b/example1.cpp
@@ -18,8 +18,7 @@ int main()
     for(int i = 0;i < Nx*Ny*Nz;i++) data[i] = std::complex<double>(rand(),rand());
 
     //save it to file
-    const std::vector<size_t> shape = {Nz,Ny,Nx};
-    cnpy::npy_save("arr1.npy",&data[0],shape,"w");
+    cnpy::npy_save("arr1.npy",&data[0],{Nz,Ny,Nx},"w");
 
     //load it into a new array
     cnpy::NpyArray arr = cnpy::npy_load("arr1.npy");
@@ -32,16 +31,15 @@ int main()
 
     //append the same data to file
     //npy array on file now has shape (Nz+Nz,Ny,Nx)
-    cnpy::npy_save("arr1.npy",&data[0],shape,"a");
+    cnpy::npy_save("arr1.npy",&data[0],{Nz,Ny,Nx},"a");
 
     //now write to an npz file
     //non-array variables are treated as 1D arrays with 1 element
     double myVar1 = 1.2;
     char myVar2 = 'a';
-    std::vector<size_t> shape2 = {1};
-    cnpy::npz_save("out.npz","myVar1",&myVar1,shape2,"w"); //"w" overwrites any existing file
-    cnpy::npz_save("out.npz","myVar2",&myVar2,shape2,"a"); //"a" appends to the file we created above
-    cnpy::npz_save("out.npz","arr1",&data[0],shape,"a"); //"a" appends to the file we created above
+    cnpy::npz_save("out.npz","myVar1",&myVar1,{1},"w"); //"w" overwrites any existing file
+    cnpy::npz_save("out.npz","myVar2",&myVar2,{1},"a"); //"a" appends to the file we created above
+    cnpy::npz_save("out.npz","arr1",&data[0],{Nz,Ny,Nx},"a"); //"a" appends to the file we created above
 
     //load a single var from the npz file
     cnpy::NpyArray arr2 = cnpy::npz_load("out.npz","arr1");

--- a/example1.cpp
+++ b/example1.cpp
@@ -11,17 +11,19 @@ const int Nz = 32;
 
 int main()
 {
+    //set random seed so that result is reproducible (for testing)
+    srand(0);
     //create random data
-    std::complex<double>* data = new std::complex<double>[Nx*Ny*Nz];
+    std::vector<std::complex<double>> data(Nx*Ny*Nz);
     for(int i = 0;i < Nx*Ny*Nz;i++) data[i] = std::complex<double>(rand(),rand());
 
     //save it to file
-    const size_t shape[] = {Nz,Ny,Nx};
-    cnpy::npy_save("arr1.npy",data,shape,3,"w");
+    const std::vector<size_t> shape = {Nz,Ny,Nx};
+    cnpy::npy_save("arr1.npy",&data[0],shape,"w");
 
     //load it into a new array
     cnpy::NpyArray arr = cnpy::npy_load("arr1.npy");
-    std::complex<double>* loaded_data = reinterpret_cast<std::complex<double>*>(arr.data);
+    std::complex<double>* loaded_data = arr.data<std::complex<double>>();
     
     //make sure the loaded data matches the saved data
     assert(arr.word_size == sizeof(std::complex<double>));
@@ -30,16 +32,16 @@ int main()
 
     //append the same data to file
     //npy array on file now has shape (Nz+Nz,Ny,Nx)
-    cnpy::npy_save("arr1.npy",data,shape,3,"a");
+    cnpy::npy_save("arr1.npy",&data[0],shape,"a");
 
     //now write to an npz file
     //non-array variables are treated as 1D arrays with 1 element
     double myVar1 = 1.2;
     char myVar2 = 'a';
-    size_t shape2[] = {1};
-    cnpy::npz_save("out.npz","myVar1",&myVar1,shape2,1,"w"); //"w" overwrites any existing file
-    cnpy::npz_save("out.npz","myVar2",&myVar2,shape2,1,"a"); //"a" appends to the file we created above
-    cnpy::npz_save("out.npz","arr1",data,shape,3,"a"); //"a" appends to the file we created above
+    std::vector<size_t> shape2 = {1};
+    cnpy::npz_save("out.npz","myVar1",&myVar1,shape2,"w"); //"w" overwrites any existing file
+    cnpy::npz_save("out.npz","myVar2",&myVar2,shape2,"a"); //"a" appends to the file we created above
+    cnpy::npz_save("out.npz","arr1",&data[0],shape,"a"); //"a" appends to the file we created above
 
     //load a single var from the npz file
     cnpy::NpyArray arr2 = cnpy::npz_load("out.npz","arr1");
@@ -49,13 +51,7 @@ int main()
     
     //check that the loaded myVar1 matches myVar1
     cnpy::NpyArray arr_mv1 = my_npz["myVar1"];
-    double* mv1 = reinterpret_cast<double*>(arr_mv1.data);
+    double* mv1 = arr_mv1.data<double>();
     assert(arr_mv1.shape.size() == 1 && arr_mv1.shape[0] == 1);
     assert(mv1[0] == myVar1);
-
-    //cleanup: note that we are responsible for deleting all loaded data
-    delete[] data;
-    delete[] loaded_data;
-    arr2.destruct();
-    my_npz.destruct();
 }


### PR DESCRIPTION
The main changes are as follows:
1) Use portable datatypes (e.g. "unsigned int" is not guaranteed to be 32 bits but "uint32_t" is).
2) It is no longer necessary to manually free the data.  In fact "delete" or "destruct" is not called anywhere now.  Memory is freed when objects go out of scope.
3) std::vector is used in place of arrays, and also for "shape" parameters.

Unfortunately, the API is now different (see example1.cpp) and also C++11 is needed.
