### PR TITLE
cnpy.cpp: fix memory leak in parsing shape field

### DIFF
--- a/cnpy.cpp
+++ b/cnpy.cpp
@@ -133,6 +133,7 @@ cnpy::NpyArray load_the_npy_file(FILE* fp) {
     cnpy::NpyArray arr;
     arr.word_size = word_size;
     arr.shape = std::vector<unsigned int>(shape,shape+ndims);
+    delete[] shape;
     arr.data = new char[size*word_size];    
     arr.fortran_order = fortran_order;
     size_t nread = fread(arr.data,word_size,size,fp);


### PR DESCRIPTION
The shape array created at cnpy.cpp:80 was never delete-ed. Add a
delete[] call at cnpy.cpp:136 to address this. A better solution may be
to pass a std::vector<> reference to parse_npy_header().