### PR TITLE
Some fixes for cross compilation

### DIFF
--- a/CMAKE-cross.txt
+++ b/CMAKE-cross.txt
@@ -1,0 +1,14 @@
+# this one is important
+SET(CMAKE_SYSTEM_NAME Linux)
+#this one not so much
+SET(CMAKE_SYSTEM_VERSION 1)
+
+# specify the cross compiler
+SET(CMAKE_C_COMPILER   <Path to aarch64-linux-android-gcc>)
+SET(CMAKE_CXX_COMPILER <Path to aarch64-linux-android-g++>)
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,12 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 option(ENABLE_STATIC "Build static (.a) library" ON)
 
-find_package(ZLIB REQUIRED)
+option(ENABLE_ZLIB "Build zlip API" ON)
+
+if(ENABLE_ZLIB)
+    find_package(ZLIB REQUIRED)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_ZLIB_API")
+endif(ENABLE_ZLIB)
 
 include_directories(${ZLIB_INCLUDE_DIRS})
 

--- a/README.md
+++ b/README.md
@@ -51,5 +51,13 @@ struct NpyArray {
     template<typename T> T* data();
 };
 ```
+# Cross Compilation
+Use CMAKE-cross.txt as ref to configure your cross tools paths.
+
+Use below command to configure the make
+Command: cmake -DCMAKE_TOOLCHAIN_FILE=./CMAKE-cross.txt .
+
+# Zlib:
+Turn off ENABLE_ZLIB in CMakeLists.txt to disable ZLIB API - by default it's on.
 
 See [example1.cpp](example1.cpp) for examples of how to use the library. example1 will also be build during cmake installation.

--- a/cnpy.cpp
+++ b/cnpy.cpp
@@ -187,6 +187,7 @@ cnpy::NpyArray load_the_npy_file(FILE* fp) {
     return arr;
 }
 
+#ifdef ENABLE_ZLIB_API
 cnpy::NpyArray load_the_npz_array(FILE* fp, uint32_t compr_bytes, uint32_t uncompr_bytes) {
 
     std::vector<unsigned char> buffer_compr(compr_bytes);
@@ -324,6 +325,7 @@ cnpy::NpyArray cnpy::npz_load(std::string fname, std::string varname) {
     printf("npz_load: Error! Variable name %s not found in %s!\n",varname.c_str(),fname.c_str());
     abort();
 }
+#endif // ENABLE_ZLIB_API
 
 cnpy::NpyArray cnpy::npy_load(std::string fname) {
 
@@ -339,6 +341,5 @@ cnpy::NpyArray cnpy::npy_load(std::string fname) {
     fclose(fp);
     return arr;
 }
-
 
 

--- a/cnpy.h
+++ b/cnpy.h
@@ -13,7 +13,9 @@
 #include<typeinfo>
 #include<iostream>
 #include<cassert>
+#ifdef ENABLE_ZLIB_API
 #include<zlib.h>
+#endif
 #include<map>
 #include<memory>
 #include<stdint.h>
@@ -130,6 +132,7 @@ namespace cnpy {
         fclose(fp);
     }
 
+#ifdef ENABLE_ZLIB_API
     template<typename T> void npz_save(std::string zipname, std::string fname, const T* data, const std::vector<size_t>& shape, std::string mode = "w")
     {
         //first, append a .npy to the fname
@@ -219,6 +222,7 @@ namespace cnpy {
         fwrite(&footer[0],sizeof(char),footer.size(),fp);
         fclose(fp);
     }
+#endif //ENABLE_ZLIB_API
 
     template<typename T> void npy_save(std::string fname, const std::vector<T> data, std::string mode = "w") {
         std::vector<size_t> shape;
@@ -232,18 +236,25 @@ namespace cnpy {
         npz_save(zipname, fname, &data[0], shape, mode);
     }
 
+    template <typename T> std::string to_string(T value)
+    {
+        std::ostringstream os ;
+	os << value ;
+	return os.str() ;
+    }
+
     template<typename T> std::vector<char> create_npy_header(const std::vector<size_t>& shape) {  
 
         std::vector<char> dict;
         dict += "{'descr': '";
         dict += BigEndianTest();
         dict += map_type(typeid(T));
-        dict += std::to_string(sizeof(T));
+        dict += to_string(sizeof(T));
         dict += "', 'fortran_order': False, 'shape': (";
-        dict += std::to_string(shape[0]);
+        dict += to_string(shape[0]);
         for(size_t i = 1;i < shape.size();i++) {
             dict += ", ";
-            dict += std::to_string(shape[i]);
+            dict += to_string(shape[i]);
         }
         if(shape.size() == 1) dict += ",";
         dict += "), }";

--- a/example1.cpp
+++ b/example1.cpp
@@ -33,6 +33,7 @@ int main()
     //npy array on file now has shape (Nz+Nz,Ny,Nx)
     cnpy::npy_save("arr1.npy",&data[0],{Nz,Ny,Nx},"a");
 
+#ifdef ENABLE_ZLIB_API
     //now write to an npz file
     //non-array variables are treated as 1D arrays with 1 element
     double myVar1 = 1.2;
@@ -52,4 +53,6 @@ int main()
     double* mv1 = arr_mv1.data<double>();
     assert(arr_mv1.shape.size() == 1 && arr_mv1.shape[0] == 1);
     assert(mv1[0] == myVar1);
+#endif //ENABLE_ZLIP_API
+
 }


### PR DESCRIPTION
* Some options for cross compilation.
* Optional ZLIB option.
* to_string : Local implementation to support cross compilers (Android don't have to_string).