### PR TITLE
libzip based zip file handling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "extern/libzippp"]
+	path = extern/libzippp
+	url = https://github.com/leezu/libzippp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,33 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0 FATAL_ERROR)
-if(COMMAND cmake_policy)
-	cmake_policy(SET CMP0003 NEW)
-endif(COMMAND cmake_policy)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
 project(CNPY)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+# Update submodules as needed
+find_package(Git QUIET)
+if(GIT_FOUND)
+    option(GIT_SUBMODULE "Check submodules during build" ON)
+    if(GIT_SUBMODULE)
+        message(STATUS "Submodule update")
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                        RESULT_VARIABLE GIT_SUBMOD_RESULT)
+        if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+            message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+        endif()
+    endif()
+endif()
 
 option(ENABLE_STATIC "Build static (.a) library" ON)
 
-find_package(ZLIB REQUIRED)
-
-include_directories(${ZLIB_INCLUDE_DIRS})
+SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+FIND_PACKAGE(LibZip REQUIRED)
 
 add_library(cnpy SHARED "cnpy.cpp")
-target_link_libraries(cnpy ${ZLIB_LIBRARIES})
+target_include_directories(cnpy PUBLIC ${LIBZIP_INCLUDE_DIR_ZIP})
+target_include_directories(cnpy PUBLIC "extern/libzippp/")
+target_link_libraries(cnpy ${LIBZIP_LIBRARIES})
+target_compile_features(cnpy PRIVATE cxx_std_14)
+
 install(TARGETS "cnpy" LIBRARY DESTINATION lib PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
 if(ENABLE_STATIC)

--- a/cmake/FindLibZip.cmake
+++ b/cmake/FindLibZip.cmake
@@ -1,0 +1,18 @@
+find_package(PkgConfig)
+pkg_check_modules(PC_LIBZIP QUIET libzip)
+set(LIBZIP_DEFINITIONS ${PC_LIBZIP_CFLAGS_OTHER})
+
+find_path(LIBZIP_INCLUDE_DIR zip.h
+          HINTS ${PC_LIBZIP_INCLUDEDIR} ${PC_LIBZIPP_INCLUDE_DIRS}
+          PATH_SUFFIXES zip )
+
+find_library(LIBZIP_LIBRARY NAMES zip libzip
+             HINTS ${PC_LIBZIP_LIBDIR} ${PC_LIBZIP_LIBRARY_DIRS} )
+
+set(LIBZIP_LIBRARIES ${LIBZIP_LIBRARY} )
+set(LIBZIP_INCLUDE_DIRS ${LIBZIP_INCLUDE_DIR} )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(libzip  DEFAULT_MSG LIBZIP_LIBRARY LIBZIP_INCLUDE_DIR)
+
+mark_as_advanced(LIBZIP_INCLUDE_DIR LIBZIP_LIBRARY )

--- a/cnpy.h
+++ b/cnpy.h
@@ -6,6 +6,7 @@
 #define LIBCNPY_H_
 
 #include<string>
+#include<cstring>
 #include<stdexcept>
 #include<sstream>
 #include<vector>
@@ -18,6 +19,8 @@
 #include<memory>
 #include<stdint.h>
 #include<numeric>
+
+#include "./zip.hpp"
 
 namespace cnpy {
 
@@ -66,7 +69,7 @@ namespace cnpy {
     char map_type(const std::type_info& t);
     template<typename T> std::vector<char> create_npy_header(const std::vector<size_t>& shape);
     void parse_npy_header(FILE* fp,size_t& word_size, std::vector<size_t>& shape, bool& fortran_order);
-    void parse_npy_header(unsigned char* buffer,size_t& word_size, std::vector<size_t>& shape, bool& fortran_order);
+    void parse_npy_header(std::string &buffer,size_t& word_size, std::vector<size_t>& shape, bool& fortran_order);
     void parse_zip_footer(FILE* fp, uint16_t& nrecs, size_t& global_header_size, size_t& global_header_offset);
     npz_t npz_load(std::string fname);
     NpyArray npz_load(std::string fname, std::string varname);
@@ -130,94 +133,45 @@ namespace cnpy {
         fclose(fp);
     }
 
-    template<typename T> void npz_save(std::string zipname, std::string fname, const T* data, const std::vector<size_t>& shape, std::string mode = "w")
-    {
-        //first, append a .npy to the fname
-        fname += ".npy";
+    template <typename T>
+    void npz_save(std::string zipname, std::string fname, const T *data,
+                  const std::vector<size_t> &shape, std::string mode = "w") {
+      libzip::flags_t flag = 0;
+      if (mode == "a") {
+      } else if (mode == "w") {
+        flag = ZIP_TRUNCATE | ZIP_CREATE;
+      } else {
+        throw std::runtime_error("npz_save: Invalid mode.");
+      }
+      libzip::archive zip(zipname, flag);
 
-        //now, on with the show
-        FILE* fp = NULL;
-        uint16_t nrecs = 0;
-        size_t global_header_offset = 0;
-        std::vector<char> global_header;
+      std::vector<char> npy_header = create_npy_header<T>(shape);
 
-        if(mode == "a") fp = fopen(zipname.c_str(),"r+b");
+      // Prepare buffer
+      size_t nels = std::accumulate(shape.begin(), shape.end(), 1,
+                                    std::multiplies<size_t>());
+      size_t nbytes = nels * sizeof(T) + npy_header.size();
 
-        if(fp) {
-            //zip file exists. we need to add a new npy file to it.
-            //first read the footer. this gives us the offset and size of the global header
-            //then read and store the global header.
-            //below, we will write the the new data at the start of the global header then append the global header and footer below it
-            size_t global_header_size;
-            parse_zip_footer(fp,nrecs,global_header_size,global_header_offset);
-            fseek(fp,global_header_offset,SEEK_SET);
-            global_header.resize(global_header_size);
-            size_t res = fread(&global_header[0],sizeof(char),global_header_size,fp);
-            if(res != global_header_size){
-                throw std::runtime_error("npz_save: header read error while adding to existing zip");
-            }
-            fseek(fp,global_header_offset,SEEK_SET);
+
+      auto ptr = static_cast<char *>(std::malloc(nbytes));
+      if (ptr == nullptr)
+        throw std::runtime_error(std::strerror(errno));
+      std::memcpy(ptr, npy_header.data(), npy_header.size());
+      std::memcpy(ptr + npy_header.size(), data, nels * sizeof(T));
+
+      // Create source buffer functor - memory will be freed automatically
+      libzip::source source =
+          [ ptr, nbytes ](struct zip * archive) -> struct zip_source * {
+        auto src = zip_source_buffer(archive, ptr, nbytes, 1);
+        if (src == nullptr) {
+          std::free(ptr);
+          throw std::runtime_error(zip_strerror(archive));
         }
-        else {
-            fp = fopen(zipname.c_str(),"wb");
-        }
+        return src;
+      };
 
-        std::vector<char> npy_header = create_npy_header<T>(shape);
-
-        size_t nels = std::accumulate(shape.begin(),shape.end(),1,std::multiplies<size_t>());
-        size_t nbytes = nels*sizeof(T) + npy_header.size();
-
-        //get the CRC of the data to be added
-        uint32_t crc = crc32(0L,(uint8_t*)&npy_header[0],npy_header.size());
-        crc = crc32(crc,(uint8_t*)data,nels*sizeof(T));
-
-        //build the local header
-        std::vector<char> local_header;
-        local_header += "PK"; //first part of sig
-        local_header += (uint16_t) 0x0403; //second part of sig
-        local_header += (uint16_t) 20; //min version to extract
-        local_header += (uint16_t) 0; //general purpose bit flag
-        local_header += (uint16_t) 0; //compression method
-        local_header += (uint16_t) 0; //file last mod time
-        local_header += (uint16_t) 0;     //file last mod date
-        local_header += (uint32_t) crc; //crc
-        local_header += (uint32_t) nbytes; //compressed size
-        local_header += (uint32_t) nbytes; //uncompressed size
-        local_header += (uint16_t) fname.size(); //fname length
-        local_header += (uint16_t) 0; //extra field length
-        local_header += fname;
-
-        //build global header
-        global_header += "PK"; //first part of sig
-        global_header += (uint16_t) 0x0201; //second part of sig
-        global_header += (uint16_t) 20; //version made by
-        global_header.insert(global_header.end(),local_header.begin()+4,local_header.begin()+30);
-        global_header += (uint16_t) 0; //file comment length
-        global_header += (uint16_t) 0; //disk number where file starts
-        global_header += (uint16_t) 0; //internal file attributes
-        global_header += (uint32_t) 0; //external file attributes
-        global_header += (uint32_t) global_header_offset; //relative offset of local file header, since it begins where the global header used to begin
-        global_header += fname;
-
-        //build footer
-        std::vector<char> footer;
-        footer += "PK"; //first part of sig
-        footer += (uint16_t) 0x0605; //second part of sig
-        footer += (uint16_t) 0; //number of this disk
-        footer += (uint16_t) 0; //disk where footer starts
-        footer += (uint16_t) (nrecs+1); //number of records on this disk
-        footer += (uint16_t) (nrecs+1); //total number of records
-        footer += (uint32_t) global_header.size(); //nbytes of global headers
-        footer += (uint32_t) (global_header_offset + nbytes + local_header.size()); //offset of start of global headers, since global header now starts after newly written array
-        footer += (uint16_t) 0; //zip file comment length
-
-        //write everything
-        fwrite(&local_header[0],sizeof(char),local_header.size(),fp);
-        fwrite(&npy_header[0],sizeof(char),npy_header.size(),fp);
-        fwrite(data,sizeof(T),nels,fp);
-        fwrite(&global_header[0],sizeof(char),global_header.size(),fp);
-        fwrite(&footer[0],sizeof(char),footer.size(),fp);
-        fclose(fp);
+      // Write everything
+      zip.add(source, fname + ".npy");
     }
 
     template<typename T> void npy_save(std::string fname, const std::vector<T> data, std::string mode = "w") {

--- a/cnpy.h
+++ b/cnpy.h
@@ -135,7 +135,8 @@ namespace cnpy {
 
     template <typename T>
     void npz_save(std::string zipname, std::string fname, const T *data,
-                  const std::vector<size_t> &shape, std::string mode = "w") {
+                  const std::vector<size_t> &shape, std::string mode = "w",
+                  int32_t comp = ZIP_CM_STORE) {
       libzip::flags_t flag = 0;
       if (mode == "a") {
       } else if (mode == "w") {
@@ -171,7 +172,8 @@ namespace cnpy {
       };
 
       // Write everything
-      zip.add(source, fname + ".npy");
+      uint64_t index = zip.add(source, fname + ".npy");
+      zip.set_file_compression(index, comp);
     }
 
     template<typename T> void npy_save(std::string fname, const std::vector<T> data, std::string mode = "w") {

--- a/cnpy.h
+++ b/cnpy.h
@@ -247,10 +247,12 @@ namespace cnpy {
         }
         if(shape.size() == 1) dict += ",";
         dict += "), }";
-        //pad with spaces so that preamble+dict is modulo 16 bytes. preamble is 10 bytes. dict needs to end with \n
-        int remainder = 16 - (10 + dict.size()) % 16;
-        dict.insert(dict.end(),remainder,' ');
-        dict.back() = '\n';
+        // pad with spaces so that preamble+dict is modulo 64 bytes. preamble is
+        // 10 bytes. dict needs to end with \n
+        int remainder = 64 - (10 + dict.size() + 1) % 64;
+        dict.insert(dict.end(), remainder, ' ');
+        dict.push_back('\n');
+        assert((dict.size() + 10) % 64 == 0);
 
         std::vector<char> header;
         header += (char) 0x93;


### PR DESCRIPTION
This removes the custom zip file handling code and uses libzip instead. This addresses the missing Zip64 support (ie. the inability to write npz files with large arrays; https://github.com/rogersce/cnpy/issues/39). For ease of usage, the libzip++ C++ bindings are used. A submodule with the libzip++ header is included and [cmake is set up to make sure the submodule is automatically initialized](https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html). This uses some C++14 features, but support should be sufficiently widespread by now I guess.
I believe it is simpler and more safe to rely on libzip instead of adding custom code to cnpy to handle Zip64 support while remaining compatible with the currently used Zip format. libzip handles this and other Zip extensions transparently.

This should also fix reading the header_length field in `parse_npy_header` on big-endian systems.

If you're unhappy with introducing new dependencies and raising the requirement, feel free to close this. I will keep the code around as a fork for anyone that is willing to make the trade-off and requires Zip64 support. But of course it would be great if this can be merged in some way so that other people don't run into similar issues. Please let me know what you think. I may add some more documentation in case you would like to merge this at some point.