### PR TITLE
Adding target options to cnpy-static to be linked against as a subdirectory module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ install(TARGETS "cnpy" LIBRARY DESTINATION lib PERMISSIONS OWNER_READ OWNER_WRIT
 
 if(ENABLE_STATIC)
     add_library(cnpy-static STATIC "cnpy.cpp")
+    target_link_libraries(cnpy-static PUBLIC ${ZLIB_LIBRARIES})
+    target_include_directories(cnpy-static PUBLIC ".")
     set_target_properties(cnpy-static PROPERTIES OUTPUT_NAME "cnpy")
     install(TARGETS "cnpy-static" ARCHIVE DESTINATION lib)
 endif(ENABLE_STATIC)


### PR DESCRIPTION
Hi,

I added a couple lines in the CMakeFiles.txt to be able to build against the static library. It works when the library is built using `add_subdirectory` and should not impact existing targets.