### PR TITLE
Multiply word_size by 4 in parse_npy_header for dtype 'U'

### DIFF
--- a/cnpy.cpp
+++ b/cnpy.cpp
@@ -99,6 +99,10 @@ void cnpy::parse_npy_header(unsigned char* buffer,size_t& word_size, std::vector
     std::string str_ws = header.substr(loc1+2);
     loc2 = str_ws.find("'");
     word_size = atoi(str_ws.substr(0,loc2).c_str());
+
+    //Special case: Unicode chars -- these have 4 bytes!
+    if(header[loc1+1] == 'U')
+        word_size *= 4;
 }
 
 void cnpy::parse_npy_header(FILE* fp, size_t& word_size, std::vector<size_t>& shape, bool& fortran_order) {  


### PR DESCRIPTION
For Unicode data, the NumPy "length" refers to characters, not bytes, specifically UCS-4/UTF-32 encoded characters, so we need 4 bytes of storage for each element.