### PR TITLE
Add support for signed types

### DIFF
--- a/cnpy.cpp
+++ b/cnpy.cpp
@@ -28,6 +28,12 @@ char cnpy::map_type(const std::type_info& t)
     if(t == typeid(short) ) return 'i';
     if(t == typeid(long) ) return 'i';
     if(t == typeid(long long) ) return 'i';
+    // These may have different typeids so they must also be included.
+    if(t == typeid(signed int) ) return 'i';
+    if(t == typeid(signed char) ) return 'i';
+    if(t == typeid(signed short) ) return 'i';
+    if(t == typeid(signed long) ) return 'i';
+    if(t == typeid(signed long long) ) return 'i';
 
     if(t == typeid(unsigned char) ) return 'u';
     if(t == typeid(unsigned short) ) return 'u';


### PR DESCRIPTION
Even though "int" by default is signed, "signed int" has a different typeid. Although most developers probably won't use "signed int" directly, a lot of compilers define int8_t, int16_t, etc. with these signed types. For example, the following code gives an invalid .npy file (compiled with GCC 7.4.0 on Ubuntu 20.04):

```
#include <cstdint>
#include <vector>
using namespace std;

#include "cnpy.h"

int main() {
  vector<int8_t> vec(20);
  for (int i = 0; i < 20; i++) vec[i] = 2 * i;
  cnpy::npy_save("hi.npy", vec.data(), {20});
}
```

When I try to load `hi.npy` in Python, I get the following error: `ValueError: descr is not a valid dtype descriptor: '<?1'` because cnpy couldn't decide if `int8_t` was signed or not.