### PR TITLE
Fix a mis-parse of NPY v2.0 and 3.0 headers

### DIFF
--- a/cnpy.cpp
+++ b/cnpy.cpp
@@ -63,8 +63,13 @@ void cnpy::parse_npy_header(unsigned char* buffer,size_t& word_size, std::vector
     //std::string magic_string(buffer,6);
     uint8_t major_version = *reinterpret_cast<uint8_t*>(buffer+6);
     uint8_t minor_version = *reinterpret_cast<uint8_t*>(buffer+7);
-    uint16_t header_len = *reinterpret_cast<uint16_t*>(buffer+8);
-    std::string header(reinterpret_cast<char*>(buffer+9),header_len);
+    bool extended_header = (major_version > 1);
+    uint32_t header_len;
+    if (extended_header)
+      header_len = *reinterpret_cast<uint32_t*>(buffer+8);
+    else
+      header_len = *reinterpret_cast<uint16_t*>(buffer+8);
+    std::string header(reinterpret_cast<char*>(buffer+(extended_header ? 11 : 9)),header_len);
 
     size_t loc1, loc2;
 

--- a/cnpy.cpp
+++ b/cnpy.cpp
@@ -69,7 +69,7 @@ void cnpy::parse_npy_header(unsigned char* buffer,size_t& word_size, std::vector
       header_len = *reinterpret_cast<uint32_t*>(buffer+8);
     else
       header_len = *reinterpret_cast<uint16_t*>(buffer+8);
-    std::string header(reinterpret_cast<char*>(buffer+(extended_header ? 11 : 9)),header_len);
+    std::string header(reinterpret_cast<char*>(buffer+(extended_header ? 12 : 10)),header_len);
 
     size_t loc1, loc2;
 


### PR DESCRIPTION
CNPY originally only supported NPY 1.0 headers, with a 2-byte length field. This PR causes `parse_npy_header()` to respond to NPY 2.0 and 3.0 by reading the header length as 4 bytes.