### PR TITLE
Make initial shape accumulate value type explicit

### DIFF
--- a/cnpy.h
+++ b/cnpy.h
@@ -121,7 +121,7 @@ namespace cnpy {
         }
 
         std::vector<char> header = create_npy_header<T>(true_data_shape);
-        size_t nels = std::accumulate(shape.begin(),shape.end(),1,std::multiplies<size_t>());
+        size_t nels = std::accumulate(shape.begin(),shape.end(),(size_t)1,std::multiplies<size_t>());
 
         fseek(fp,0,SEEK_SET);
         fwrite(&header[0],sizeof(char),header.size(),fp);
@@ -164,7 +164,7 @@ namespace cnpy {
 
         std::vector<char> npy_header = create_npy_header<T>(shape);
 
-        size_t nels = std::accumulate(shape.begin(),shape.end(),1,std::multiplies<size_t>());
+        size_t nels = std::accumulate(shape.begin(),shape.end(),(size_t)1,std::multiplies<size_t>());
         size_t nbytes = nels*sizeof(T) + npy_header.size();
 
         //get the CRC of the data to be added


### PR DESCRIPTION
On many compilers (tested on gcc 9.2) the std::accumulate function will use the type of the initial value as the accumulated value type. The previous version of the code passed a literal '1' which defaults to an 'int' type. This makes the code vulnerable to type overflows for arrays with many elements. Explicitly casting to size_t should fix this.