### PR TITLE
Add combined iOS/simulator support when building with Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,15 @@ find_package(ZLIB REQUIRED)
 include_directories(${ZLIB_INCLUDE_DIRS})
 
 add_library(cnpy SHARED "cnpy.cpp")
+# create alias with exported name for including via find_package or FetchContent
+add_library(Cnpy::Cnpy ALIAS cnpy)
+target_include_directories(cnpy
+    PUBLIC
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+    PRIVATE
+      ${CMAKE_SOURCE_DIR}
+)
 target_link_libraries(cnpy ${ZLIB_LIBRARIES})
 
 include(GNUInstallDirs)
@@ -72,3 +81,4 @@ install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/CnpyConfigVersion.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Cnpy
 )
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT IOS)
   find_package(ZLIB REQUIRED)
   target_link_libraries(cnpy ZLIB::ZLIB)
 else()
-  target_link_libraries(cnpy)
+  target_link_libraries(cnpy "-lz")
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,16 +15,60 @@ include_directories(${ZLIB_INCLUDE_DIRS})
 
 add_library(cnpy SHARED "cnpy.cpp")
 target_link_libraries(cnpy ${ZLIB_LIBRARIES})
-install(TARGETS "cnpy" LIBRARY DESTINATION lib PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+include(GNUInstallDirs)
+
+install(TARGETS cnpy
+    EXPORT cnpy-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
+
+#This is required so that the exported target has the name JSONUtils and not jsonutils
+set_target_properties(cnpy PROPERTIES EXPORT_NAME Cnpy)
 
 if(ENABLE_STATIC)
     add_library(cnpy-static STATIC "cnpy.cpp")
     set_target_properties(cnpy-static PROPERTIES OUTPUT_NAME "cnpy")
-    install(TARGETS "cnpy-static" ARCHIVE DESTINATION lib)
+    install(TARGETS "cnpy-static"
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 endif(ENABLE_STATIC)
 
-install(FILES "cnpy.h" DESTINATION include)
-install(FILES "mat2npz" "npy2mat" "npz2mat" DESTINATION bin PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+install(FILES "cnpy.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES "mat2npz" "npy2mat" "npz2mat"
+    DESTINATION bin
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
 
 add_executable(example1 example1.cpp)
 target_link_libraries(example1 cnpy)
+
+install(EXPORT cnpy-targets
+  FILE
+    CnpyTargets.cmake
+  NAMESPACE
+    Cnpy::
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}/cmake/Cnpy
+)
+
+#Create a ConfigVersion.cmake file
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/CnpyConfigVersion.cmake
+    VERSION 0.1.0
+    COMPATIBILITY AnyNewerVersion
+)
+
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/CnpyConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/CnpyConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Cnpy
+)
+
+#Install the config, configversion and custom find modules
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/CnpyConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/CnpyConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Cnpy
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 option(ENABLE_STATIC "Build static (.a) library" ON)
 
-if(iOS)
-  link_directories("/opt/local/lib")
-endif()
-
 add_library(cnpy SHARED "cnpy.cpp")
 # create alias with exported name for including via find_package or FetchContent
 add_library(Cnpy::Cnpy ALIAS cnpy)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,7 @@ add_library(Cnpy::Cnpy ALIAS cnpy)
 target_include_directories(cnpy
     PUBLIC
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-    PRIVATE
-      ${CMAKE_SOURCE_DIR}
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 target_link_libraries(cnpy ${ZLIB_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,23 @@ find_package(ZLIB REQUIRED)
 include_directories(${ZLIB_INCLUDE_DIRS})
 
 add_library(cnpy SHARED "cnpy.cpp")
-# create alias with exported name for including via find_package or FetchContent
-add_library(Cnpy::Cnpy ALIAS cnpy)
+
 target_include_directories(cnpy
     PUBLIC
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
-target_link_libraries(cnpy ${ZLIB_LIBRARIES})
+if(NOT iOS)
+  # create alias with exported name for including via find_package or FetchContent
+  add_library(Cnpy::Cnpy ALIAS cnpy)
+  target_link_libraries(cnpy ${ZLIB_LIBRARIES})
+else()
+  # build static for iOS
+  set(ENABLE_STATIC ON)
+  # create alias with exported name for including via find_package or FetchContent
+  add_library(Cnpy::Cnpy ALIAS cnpy-static)
+  target_link_libraries(cnpy "-lz")
+endif()
 
 include(GNUInstallDirs)
 
@@ -31,25 +40,28 @@ install(TARGETS cnpy
     PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
 )
 
-#This is required so that the exported target has the name JSONUtils and not jsonutils
+#This is required so that the exported target has the name Cnpy and not cnpy
 set_target_properties(cnpy PROPERTIES EXPORT_NAME Cnpy)
 
 if(ENABLE_STATIC)
-    add_library(cnpy-static STATIC "cnpy.cpp")
-    set_target_properties(cnpy-static PROPERTIES OUTPUT_NAME "cnpy")
-    install(TARGETS "cnpy-static"
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
+  add_library(cnpy-static STATIC "cnpy.cpp")
+  set_target_properties(cnpy-static PROPERTIES OUTPUT_NAME "cnpy")
+  install(TARGETS "cnpy-static"
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
 endif(ENABLE_STATIC)
 
 install(FILES "cnpy.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES "mat2npz" "npy2mat" "npz2mat"
-    DESTINATION bin
-    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-)
 
-add_executable(example1 example1.cpp)
-target_link_libraries(example1 cnpy)
+if (NOT iOS)
+  # don't install extra utils under iOS
+  install(FILES "mat2npz" "npy2mat" "npz2mat"
+      DESTINATION bin
+      PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+  )
+  add_executable(example1 example1.cpp)
+  target_link_libraries(example1 cnpy)
+endif()
 
 install(EXPORT cnpy-targets
   FILE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(ZLIB REQUIRED)
 include_directories(${ZLIB_INCLUDE_DIRS})
 
 add_library(cnpy SHARED "cnpy.cpp")
+# create alias with exported name for including via find_package or FetchContent
+add_library(Cnpy::Cnpy ALIAS cnpy)
 
 target_include_directories(cnpy
     PUBLIC
@@ -21,14 +23,8 @@ target_include_directories(cnpy
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 if(NOT iOS)
-  # create alias with exported name for including via find_package or FetchContent
-  add_library(Cnpy::Cnpy ALIAS cnpy)
   target_link_libraries(cnpy ${ZLIB_LIBRARIES})
 else()
-  # build static for iOS
-  set(ENABLE_STATIC ON)
-  # create alias with exported name for including via find_package or FetchContent
-  add_library(Cnpy::Cnpy ALIAS cnpy-static)
   link_directories("/opt/local/lib")
   target_link_libraries(cnpy "-lz")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT iOS)
   find_package(ZLIB REQUIRED)
   target_link_libraries(cnpy ZLIB::ZLIB)
 else()
-  target_link_libraries(cnpy "-lz")
+  target_link_libraries(cnpy)
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 option(ENABLE_STATIC "Build static (.a) library" ON)
 
+if(iOS)
+  link_directories("/opt/local/lib")
+endif()
+
 add_library(cnpy SHARED "cnpy.cpp")
 # create alias with exported name for including via find_package or FetchContent
 add_library(Cnpy::Cnpy ALIAS cnpy)
@@ -22,7 +26,6 @@ if(NOT iOS)
   find_package(ZLIB REQUIRED)
   target_link_libraries(cnpy ZLIB::ZLIB)
 else()
-  link_directories("/opt/local/lib")
   target_link_libraries(cnpy "-lz")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ else()
   set(ENABLE_STATIC ON)
   # create alias with exported name for including via find_package or FetchContent
   add_library(Cnpy::Cnpy ALIAS cnpy-static)
+  link_directories("/opt/local/lib")
   target_link_libraries(cnpy "-lz")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(cnpy
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
-if(NOT iOS)
+if(NOT IOS)
   find_package(ZLIB REQUIRED)
   target_link_libraries(cnpy ZLIB::ZLIB)
 else()
@@ -46,7 +46,7 @@ endif(ENABLE_STATIC)
 
 install(FILES "cnpy.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-if (NOT iOS)
+if (NOT IOS)
   # don't install extra utils under iOS
   install(FILES "mat2npz" "npy2mat" "npz2mat"
       DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 option(ENABLE_STATIC "Build static (.a) library" ON)
 
-find_package(ZLIB REQUIRED)
-
-include_directories(${ZLIB_INCLUDE_DIRS})
-
 add_library(cnpy SHARED "cnpy.cpp")
 # create alias with exported name for including via find_package or FetchContent
 add_library(Cnpy::Cnpy ALIAS cnpy)
@@ -23,7 +19,8 @@ target_include_directories(cnpy
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 if(NOT iOS)
-  target_link_libraries(cnpy ${ZLIB_LIBRARIES})
+  find_package(ZLIB REQUIRED)
+  target_link_libraries(cnpy ZLIB::ZLIB)
 else()
   link_directories("/opt/local/lib")
   target_link_libraries(cnpy "-lz")

--- a/cmake/CnpyConfig.cmake.in
+++ b/cmake/CnpyConfig.cmake.in
@@ -1,7 +1,9 @@
 get_filename_component(Cnpy_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(CMakeFindDependencyMacro)
 
-find_dependency(ZLIB REQUIRED)
+if(NOT iOS)
+    find_dependency(ZLIB REQUIRED)
+endif()
 
 if(NOT TARGET Cnpy::Cnpy)
     include("${Cnpy_CMAKE_DIR}/CnpyTargets.cmake")

--- a/cmake/CnpyConfig.cmake.in
+++ b/cmake/CnpyConfig.cmake.in
@@ -1,0 +1,10 @@
+get_filename_component(Cnpy_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(CMakeFindDependencyMacro)
+
+find_dependency(ZLIB REQUIRED)
+
+if(NOT TARGET Cnpy::Cnpy)
+    include("${Cnpy_CMAKE_DIR}/CnpyTargets.cmake")
+endif()
+
+set(CNPY_lIBRARIES Cnpy::Cnpy)

--- a/cmake/CnpyConfig.cmake.in
+++ b/cmake/CnpyConfig.cmake.in
@@ -1,7 +1,7 @@
 get_filename_component(Cnpy_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include(CMakeFindDependencyMacro)
 
-if(NOT iOS)
+if(NOT IOS)
     find_dependency(ZLIB REQUIRED)
 endif()
 


### PR DESCRIPTION
Building a combined device (arm64) and simulator (x86_64) library has issues when using Cmake's `find_package()` since Cmake only runs configure once even though we have two targets. With `cnpy`, causes the arm64 version libz to get linked in to the simulator version of the `cnpy`, rather that x86_64 version.

This change uses `-lz` linker flag to search for lib in the sysroot for the appropriate SDK (device or simulator), which does get switched appropriate depending on the version of the library built.