### PR TITLE
Solve issue with Ninja / MSVC Compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ install(TARGETS "cnpy" LIBRARY DESTINATION lib PERMISSIONS OWNER_READ OWNER_WRIT
 
 if(ENABLE_STATIC)
     add_library(cnpy-static STATIC "cnpy.cpp")
-    set_target_properties(cnpy-static PROPERTIES OUTPUT_NAME "cnpy")
+    IF (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        set_target_properties(cnpy-static PROPERTIES OUTPUT_NAME "cnpystatic")
+    ELSE()
+        set_target_properties(cnpy-static PROPERTIES OUTPUT_NAME "cnpy")
+    ENDIF(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     install(TARGETS "cnpy-static" ARCHIVE DESTINATION lib)
 endif(ENABLE_STATIC)
 


### PR DESCRIPTION
Solve the following error when compiling with Ninja and MSVC (Windows):
'Ninja.exe' '-C' 'D:/workspace/cnpy/out/build/x64-debug' '-t' 'recompact'
  failed with:
ninja: error: build.ninja:116: multiple rules generate cnpyd.lib [-w dupbuild=err]		D:\workspace\cnpy\   ninja